### PR TITLE
fix: fallback to the default kubeseal binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Correct exit code if the required version of kubeseal was not found on github
+
 ## [0.4.2] - 2022-07-21
 ### Fixed
 - Correct download link for amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fallback to the default kubeseal binary if the specific version can't be downloaded
 ### Fixed
 - Correct exit code if the required version of kubeseal was not found on github
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.3] - 2022-09-06
 ### Changed
 - Fallback to the default kubeseal binary if the specific version can't be downloaded
 ### Fixed

--- a/src/kubeseal_auto/cluster.py
+++ b/src/kubeseal_auto/cluster.py
@@ -48,11 +48,10 @@ class Cluster:
                 namespace = deployment.metadata.namespace
                 version = deployment.metadata.labels["app.kubernetes.io/version"]
                 click.echo(
-                    f"===> Found the following controller: "
+                    "===> Found the following controller: "
                     f"[{Fore.CYAN}{namespace}/{name}{Fore.RESET}]\n"
                     f"===> Controller version: [{Fore.CYAN}{version}{Fore.RESET}]"
                 )
-                self.host.ensure_kubeseal_binary(version=version)
                 return {"name": name, "namespace": namespace, "version": version}
 
         click.echo("===> No controller found")
@@ -81,6 +80,9 @@ class Cluster:
             secrets.sort(key=lambda x: x["timestamp"])
 
         return secrets[-1]["name"]
+
+    def ensure_kubeseal_version(self, version: str):
+        self.host.ensure_kubeseal_binary(version=version)
 
     def get_controller_name(self):
         return self.controller["name"]

--- a/src/kubeseal_auto/host.py
+++ b/src/kubeseal_auto/host.py
@@ -50,6 +50,9 @@ class Host:
 
         click.echo(f"Downloading {url}")
         with requests.get(url) as r:
+            if r.status_code == 404:
+                click.echo(f"The required version {version} is not available")
+                exit(1)
             with open(local_path, "wb") as f:
                 f.write(r.content)
 

--- a/src/kubeseal_auto/host.py
+++ b/src/kubeseal_auto/host.py
@@ -52,7 +52,7 @@ class Host:
         with requests.get(url) as r:
             if r.status_code == 404:
                 click.echo(f"The required version {version} is not available")
-                exit(1)
+                raise FileNotFoundError
             with open(local_path, "wb") as f:
                 f.write(r.content)
 

--- a/src/kubeseal_auto/kubeseal.py
+++ b/src/kubeseal_auto/kubeseal.py
@@ -36,10 +36,6 @@ class Kubeseal:
 
         self.temp_file = NamedTemporaryFile()
 
-    def __del__(self):
-        click.echo("===> Removing temporary file")
-        self.temp_file.close()
-
     def _find_sealed_secrets(self, src: str) -> list:
         secrets = []
         for path in Path(src).rglob("*.yaml"):

--- a/src/kubeseal_auto/kubeseal.py
+++ b/src/kubeseal_auto/kubeseal.py
@@ -30,9 +30,13 @@ class Kubeseal:
             self.controller_namespace = self.cluster.get_controller_namespace()
             self.current_context_name = self.cluster.get_context()
             self.namespaces_list = self.cluster.get_all_namespaces()
-            self.binary = (
-                f"{home_dir}/bin/kubeseal-{self.cluster.get_controller_version()}"
-            )
+            version = self.cluster.get_controller_version()
+
+            try:
+                self.cluster.ensure_kubeseal_version(version)
+                self.binary = f"{home_dir}/bin/kubeseal-{version}"
+            except FileNotFoundError:
+                click.echo("==> Falling back to the default kubeseal binary")
 
         self.temp_file = NamedTemporaryFile()
 
@@ -226,7 +230,7 @@ class Kubeseal:
             click.echo(f"Re-encrypting {secret}")
             os.rename(secret, f"{secret}_tmp")
             command = (
-                f"kubeseal --format=yaml "
+                "kubeseal --format=yaml "
                 f"--context={self.current_context_name} "
                 f"--controller-namespace {self.controller_namespace} "
                 f"--controller-name {self.controller_name} "


### PR DESCRIPTION
### Changed
- Fallback to the default kubeseal binary if the specific version can't be downloaded
### Fixed
- Correct exit code if the required version of kubeseal was not found on GitHub
- Remove the redundant __del__ method as NamedTemporaryFile removes the file by default