### PR TITLE
ci(security): add scanning suite and harden workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,10 +12,14 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
+        # zizmor: ignore[cache-poisoning] tag-triggered publish; poisoning the restored cache needs push access to main (already trusted) and the wheel is built from repo src, not the cache
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: '3.12'
@@ -29,8 +32,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
+        # zizmor: ignore[cache-poisoning] tag-triggered publish; poisoning the restored cache needs push access to main (already trusted) and the wheel is built from repo src, not the cache
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: '3.12'
@@ -50,6 +56,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Extract changelog section
         run: |
@@ -84,7 +92,7 @@ jobs:
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
 
       - name: Update nixpkgs package
-        uses: shini4i/nixpkgs-updater@v1
+        uses: shini4i/nixpkgs-updater@v1 # zizmor: ignore[unpinned-uses] first-party shini4i action; policy permits semver tags
         with:
           package-name: kubeseal-auto
           version: ${{ github.ref_name }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,10 +11,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,91 @@
+name: Security
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  bandit:
+    name: Bandit (Python SAST)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run bandit
+        run: uv run bandit -r src/
+
+  trivy:
+    name: Trivy (dependency vulnerabilities)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Scan dependencies
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+
+  trufflehog:
+    name: TruffleHog (secret scan)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          # Full history so the scan can diff the pushed/PR commit range.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Scan for secrets
+        uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # v3.95.5
+        with:
+          extra_args: --results=verified,unknown
+
+  zizmor:
+    name: Zizmor (GitHub Actions audit)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Audit workflows
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          # Gate on actionable findings (low and above); informational
+          # recommendations are surfaced locally without blocking CI.
+          min-severity: low
+          online-audits: false
+          advanced-security: false
+          inputs: .github/workflows/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -68,24 +68,3 @@ jobs:
         uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # v3.95.5
         with:
           extra_args: --results=verified,unknown
-
-  zizmor:
-    name: Zizmor (GitHub Actions audit)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Audit workflows
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
-        with:
-          # Gate on actionable findings (low and above); informational
-          # recommendations are surfaced locally without blocking CI.
-          min-severity: low
-          online-audits: false
-          advanced-security: false
-          inputs: .github/workflows/

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,39 @@
+name: Workflow Audit
+
+# zizmor only ever audits the workflow definitions, so it runs solely when a
+# workflow file changes. Path filters are workflow-level (not per-job), which
+# is why this lives in its own file rather than alongside the other scanners
+# in security.yml.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+
+jobs:
+  zizmor:
+    name: Zizmor (GitHub Actions audit)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Audit workflows
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          # Gate on actionable findings (low and above); informational
+          # recommendations are surfaced locally without blocking CI.
+          min-severity: low
+          online-audits: false
+          advanced-security: false
+          inputs: .github/workflows/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,22 @@ repos:
           - types-PyYAML
           - types-requests
         args: [--ignore-missing-imports]
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        # Application code only; tests legitimately use asserts (B101).
+        files: ^src/
+
+  # Secret scanning runs locally before a commit lands, so credentials never
+  # reach a commit or CI. filesystem mode scans the staged files pre-commit
+  # passes in (so no .venv/vendored false positives, and the about-to-be-
+  # committed content is actually scanned). Uses the trufflehog binary from
+  # the flake devshell (language: system), not the upstream hook's Go build.
+  - repo: local
+    hooks:
+      - id: trufflehog
+        name: TruffleHog secret scan
+        entry: trufflehog filesystem --results=verified,unknown --fail --no-update
+        language: system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **CI security scanning** (`security.yml`): bandit (Python SAST), Trivy (dependency CVEs against `uv.lock`), TruffleHog (secret scanning), and zizmor (GitHub Actions audit), running on pull requests and pushes to `main`.
+- **CI security scanning** (`security.yml`): bandit (Python SAST), Trivy (dependency CVEs against `uv.lock`), and TruffleHog (secret scanning), running on pull requests and pushes to `main`.
+- **Workflow audit** (`zizmor.yml`): zizmor GitHub Actions audit, scoped via path filter to run only when `.github/workflows/**` changes.
 - Pre-commit hooks for bandit and TruffleHog, so Python security issues and secrets are caught locally before a commit reaches CI.
 - `bandit` added to the dev dependency group; `zizmor`, `trivy`, and `trufflehog` added to the Nix devshell.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **CI security scanning** (`security.yml`): bandit (Python SAST), Trivy (dependency CVEs against `uv.lock`), TruffleHog (secret scanning), and zizmor (GitHub Actions audit), running on pull requests and pushes to `main`.
+- Pre-commit hooks for bandit and TruffleHog, so Python security issues and secrets are caught locally before a commit reaches CI.
+- `bandit` added to the dev dependency group; `zizmor`, `trivy`, and `trufflehog` added to the Nix devshell.
+
+### Security
+
+- Hardened existing workflows: per-job least-privilege `permissions` on `run-tests.yml`/`e2e.yml` and `persist-credentials: false` on all `actions/checkout` steps, limiting the blast radius of a compromised action.
+- Documented `# nosec` annotations on the `kubeseal`/`kubectl` `subprocess` calls (fixed argv lists, no shell), keeping bandit fail-closed on any future subprocess usage.
+
 ## [0.7.1] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,3 +61,9 @@ kubeseal-auto --backup
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+### Development setup
+The pre-commit hooks include a [TruffleHog](https://github.com/trufflesecurity/trufflehog#floppy_disk-installation) secret scan that needs the `trufflehog` binary on `$PATH` (it is **not** installed by `uv sync`).
+
+- **With Nix (recommended):** `nix develop` provides `trufflehog` (and the other scanners); then `uv sync --group dev` and `pre-commit install`.
+- **Without Nix:** install `trufflehog` manually, then `uv sync --group dev` and `pre-commit install`.

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,12 @@
               kubectl
               kubeseal
               bump2version
+              # Security scanners, mirroring the CI security workflow so they can
+              # be run locally. bandit is a Python tool and lives in the uv dev
+              # group instead.
+              zizmor
+              trivy
+              trufflehog
             ];
             env = {
               # Force uv to use the interpreter from this shell, not a downloaded one.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "types-PyYAML>=6.0,<7",
     "types-requests>=2.31,<3",
     "pexpect>=4.9,<5",
+    "bandit>=1.9.4,<2",
 ]
 
 [build-system]

--- a/src/kubeseal_auto/secrets/creation.py
+++ b/src/kubeseal_auto/secrets/creation.py
@@ -4,7 +4,7 @@ This module provides functions for creating different types of
 Kubernetes secrets (generic, TLS, docker-registry).
 """
 
-import subprocess
+import subprocess  # nosec B404 - subprocess wraps kubectl (the tool's purpose); calls pass argv lists, never shell=True
 from pathlib import Path
 
 import click
@@ -20,7 +20,7 @@ _DRY_RUN_CLIENT = "--dry-run=client"
 # Error message constants
 _ERR_KUBECTL_NOT_FOUND = "kubectl not found; please install kubectl and ensure it's on PATH"
 _ERR_OUTPUT_PATH = "Cannot write to output path '{path}': {reason}"
-_ERR_SECRET_CREATION = "Failed to create {secret_type} secret (exit code {code}){details}"
+_ERR_SECRET_CREATION = "Failed to create {secret_type} secret (exit code {code}){details}"  # nosec B105 - error-message template, not a credential (flagged only because the name contains "SECRET")
 
 
 def _run_kubectl_write_output(
@@ -52,7 +52,7 @@ def _run_kubectl_write_output(
 
     with f:
         try:
-            subprocess.run(
+            subprocess.run(  # nosec B603 - fixed kubectl argv list, no shell, no untrusted command input
                 cmd,
                 input=input_data,
                 stdout=f,

--- a/src/kubeseal_auto/secrets/sealing.py
+++ b/src/kubeseal_auto/secrets/sealing.py
@@ -6,7 +6,7 @@ and backing up sealed secrets using the kubeseal binary.
 
 import contextlib
 import shutil
-import subprocess
+import subprocess  # nosec B404 - subprocess wraps the kubeseal/kubectl binaries; calls pass argv lists, never shell=True
 from pathlib import Path
 
 import click
@@ -66,7 +66,7 @@ def seal_secret(
     try:
         with console.spinner("Sealing secret with kubeseal..."):
             with open(temp_file_path, encoding="utf-8") as stdin_f, open(output_file, "w", encoding="utf-8") as stdout_f:
-                subprocess.run(kubeseal_cmd, stdin=stdin_f, stdout=stdout_f, stderr=subprocess.PIPE, check=True)
+                subprocess.run(kubeseal_cmd, stdin=stdin_f, stdout=stdout_f, stderr=subprocess.PIPE, check=True)  # nosec B603 - fixed kubeseal argv list, no shell, no untrusted command input
             append_argo_annotation(filename=output_file)
     except subprocess.CalledProcessError as err:
         # Clean up partial output file on failure
@@ -111,7 +111,7 @@ def merge_secret(
 
     try:
         with open(temp_file_path, encoding="utf-8") as stdin_f:
-            subprocess.run(cmd, stdin=stdin_f, stderr=subprocess.PIPE, check=True)
+            subprocess.run(cmd, stdin=stdin_f, stderr=subprocess.PIPE, check=True)  # nosec B603 - fixed kubeseal argv list, no shell, no untrusted command input
     except subprocess.CalledProcessError as err:
         stderr_msg = err.stderr.decode().strip() if err.stderr else ""
         error_details = f": {stderr_msg}" if stderr_msg else ""
@@ -149,7 +149,7 @@ def reencrypt_secrets(src: str, kubeseal_cmd: list[str]) -> None:
 
             try:
                 with secret.open(encoding="utf-8") as stdin_f, output_tmp.open("w", encoding="utf-8") as stdout_f:
-                    subprocess.run(cmd, stdin=stdin_f, stdout=stdout_f, stderr=subprocess.PIPE, check=True)
+                    subprocess.run(cmd, stdin=stdin_f, stdout=stdout_f, stderr=subprocess.PIPE, check=True)  # nosec B603 - fixed kubeseal argv list, no shell, no untrusted command input
                 # Atomic replace on success
                 output_tmp.replace(secret)
                 backup_path.unlink()
@@ -203,7 +203,7 @@ def fetch_certificate(
     output_file = f"{context_name}-kubeseal-cert.crt"
     try:
         with open(output_file, "w", encoding="utf-8") as f:
-            subprocess.run(cmd, stdout=f, stderr=subprocess.PIPE, check=True)
+            subprocess.run(cmd, stdout=f, stderr=subprocess.PIPE, check=True)  # nosec B603 - fixed kubeseal/kubectl argv list, no shell, no untrusted command input
     except subprocess.CalledProcessError as err:
         # Clean up partial output file on failure
         with contextlib.suppress(OSError):
@@ -246,7 +246,7 @@ def backup_controller_secret(
     output_file = f"{context_name}-secret-backup.yaml"
     try:
         with open(output_file, "w", encoding="utf-8") as f:
-            subprocess.run(cmd, stdout=f, stderr=subprocess.PIPE, check=True)
+            subprocess.run(cmd, stdout=f, stderr=subprocess.PIPE, check=True)  # nosec B603 - fixed kubeseal/kubectl argv list, no shell, no untrusted command input
     except subprocess.CalledProcessError as err:
         # Clean up partial output file on failure
         with contextlib.suppress(OSError):

--- a/uv.lock
+++ b/uv.lock
@@ -184,6 +184,21 @@ wheels = [
 ]
 
 [[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
@@ -619,7 +634,7 @@ wheels = [
 
 [[package]]
 name = "kubeseal-auto"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -632,6 +647,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit" },
     { name = "mypy" },
     { name = "pexpect" },
     { name = "pytest" },
@@ -653,6 +669,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "bandit", specifier = ">=1.9.4,<2" },
     { name = "mypy", specifier = ">=1.13.0,<2" },
     { name = "pexpect", specifier = ">=4.9,<5" },
     { name = "pytest", specifier = ">=9.0.1,<10" },
@@ -1373,6 +1390,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/88/35e4d27d9177d7df76d060e0a18f69c6c5794c96960c94042e20a12c8ba2/stevedore-5.8.0.tar.gz", hash = "sha256:b49867b32ca3016e94100e68dbf26e72aa7b8708d0a3f73c08aeb220370ac715", size = 514710, upload-time = "2026-05-18T09:15:27.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl", hash = "sha256:88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b", size = 54553, upload-time = "2026-05-18T09:15:25.82Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a Security workflow running bandit (Python SAST), Trivy (dependency CVEs via uv.lock), TruffleHog (secrets) and zizmor (Actions audit) on PRs and pushes to main, with SHA-pinned actions and per-job permissions. Mirror bandit and TruffleHog as pre-commit hooks so issues are caught before CI; add the scanners to the flake devshell and bandit to the uv dev group.

Harden existing workflows where a real threat exists: per-job least-privilege permissions and persist-credentials: false on checkouts. Document the subprocess calls with inline # nosec (fixed kubeseal/kubectl argv, no shell) so bandit stays fail-closed on future calls. zizmor findings without a realistic attacker for this repo (cache-poisoning on the tag-triggered publish, the first-party unpinned action) are ignored inline with a written rationale rather than worked around.