### PR TITLE
fix(security): pass docker password via stdin and harden backup UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ result
 .direnv/
 **/__pycache__
 **/*.crt
+*-secret-backup.yaml
 .coverage
 junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ result
 *-secret-backup.yaml
 .coverage
 junit.xml
+*.py,cover
+coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened existing workflows: per-job least-privilege `permissions` on `run-tests.yml`/`e2e.yml` and `persist-credentials: false` on all `actions/checkout` steps, limiting the blast radius of a compromised action.
 - Documented `# nosec` annotations on the `kubeseal`/`kubectl` `subprocess` calls (fixed argv lists, no shell), keeping bandit fail-closed on any future subprocess usage.
 - Docker registry passwords are now passed to `kubectl` via stdin (`--docker-password=-`) instead of as a CLI argument, keeping the password out of `/proc/*/cmdline`.
+- Controller encryption key backups now display a prominent warning about the sensitivity of the exported private key, and `*-secret-backup.yaml` files are excluded from version control via `.gitignore`.
 
 ## [0.7.1] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Hardened existing workflows: per-job least-privilege `permissions` on `run-tests.yml`/`e2e.yml` and `persist-credentials: false` on all `actions/checkout` steps, limiting the blast radius of a compromised action.
 - Documented `# nosec` annotations on the `kubeseal`/`kubectl` `subprocess` calls (fixed argv lists, no shell), keeping bandit fail-closed on any future subprocess usage.
+- Docker registry passwords are now passed to `kubectl` via stdin (`--docker-password=-`) instead of as a CLI argument, keeping the password out of `/proc/*/cmdline`.
 
 ## [0.7.1] - 2026-06-11
 

--- a/src/kubeseal_auto/core/kubeseal.py
+++ b/src/kubeseal_auto/core/kubeseal.py
@@ -134,7 +134,8 @@ class Kubeseal:
 
     def _cleanup_temp_file(self) -> None:
         """Remove the temporary file if it exists."""
-        atexit.unregister(self._cleanup_temp_file)
+        with contextlib.suppress(ValueError):
+            atexit.unregister(self._cleanup_temp_file)
         if hasattr(self, "_temp_file_path"):
             with contextlib.suppress(OSError):
                 self._temp_file_path.unlink(missing_ok=True)
@@ -207,14 +208,22 @@ class Kubeseal:
         """
         create_generic_secret(secret_params, self._temp_file_path)
 
-    def create_tls_secret(self, secret_params: SecretParams) -> None:
+    def create_tls_secret(
+        self,
+        secret_params: SecretParams,
+        *,
+        key_path: Path = Path("tls.key"),
+        cert_path: Path = Path("tls.crt"),
+    ) -> None:
         """Generate a temporary TLS secret YAML file.
 
         Args:
             secret_params: SecretParams containing name and namespace.
+            key_path: Path to the TLS key file (default: ``tls.key`` in CWD).
+            cert_path: Path to the TLS certificate file (default: ``tls.crt`` in CWD).
 
         """
-        create_tls_secret(secret_params, self._temp_file_path)
+        create_tls_secret(secret_params, self._temp_file_path, key_path=key_path, cert_path=cert_path)
 
     def create_regcred_secret(self, secret_params: SecretParams) -> None:
         """Generate a temporary docker-registry secret YAML file.

--- a/src/kubeseal_auto/core/kubeseal.py
+++ b/src/kubeseal_auto/core/kubeseal.py
@@ -97,8 +97,10 @@ class Kubeseal:
                 )
                 self._fallback_to_system_binary()
 
-        # Create temp file with delete=False for Windows compatibility
-        # Close immediately to avoid file locking issues when reopening
+        # Obtain a guaranteed-unique temporary path for the unsealed secret.
+        # NamedTemporaryFile is used only for its unique-name guarantee; the
+        # file is closed immediately and the actual secret content is written
+        # later by kubectl via _run_kubectl_write_output.
         temp_file = NamedTemporaryFile(delete=False)
         self._temp_file_path: Path = Path(temp_file.name)
         temp_file.close()

--- a/src/kubeseal_auto/secrets/creation.py
+++ b/src/kubeseal_auto/secrets/creation.py
@@ -106,30 +106,33 @@ def create_generic_secret(secret_params: SecretParams, output_path: Path) -> Non
     _run_kubectl_write_output(cmd, output_path, "generic")
 
 
-def create_tls_secret(secret_params: SecretParams, output_path: Path) -> None:
+def create_tls_secret(
+    secret_params: SecretParams,
+    output_path: Path,
+    *,
+    key_path: Path = Path("tls.key"),
+    cert_path: Path = Path("tls.crt"),
+) -> None:
     """Generate a temporary TLS secret YAML file.
-
-    Expects tls.key and tls.crt files to exist in the current directory.
 
     Args:
         secret_params: SecretParams containing name and namespace.
         output_path: Path where the temporary secret YAML will be written.
+        key_path: Path to the TLS key file (default: ``tls.key`` in CWD).
+        cert_path: Path to the TLS certificate file (default: ``tls.crt`` in CWD).
 
     Raises:
-        click.ClickException: If tls.key or tls.crt files do not exist.
+        click.ClickException: If the TLS key or certificate files do not exist.
 
     """
-    key_file = Path("tls.key")
-    cert_file = Path("tls.crt")
-
     missing_files = []
-    if not key_file.exists():
-        missing_files.append("tls.key")
-    if not cert_file.exists():
-        missing_files.append("tls.crt")
+    if not key_path.exists():
+        missing_files.append(str(key_path))
+    if not cert_path.exists():
+        missing_files.append(str(cert_path))
 
     if missing_files:
-        raise click.ClickException(f"Required TLS file(s) not found in current directory: {', '.join(missing_files)}")
+        raise click.ClickException(f"Required TLS file(s) not found: {', '.join(missing_files)}")
 
     console.step("Generating temporary TLS secret yaml file")
     cmd: list[str] = [
@@ -141,9 +144,9 @@ def create_tls_secret(secret_params: SecretParams, output_path: Path) -> None:
         "--namespace",
         secret_params.namespace,
         "--key",
-        str(key_file),
+        str(key_path),
         "--cert",
-        str(cert_file),
+        str(cert_path),
         _DRY_RUN_CLIENT,
         "-o",
         "yaml",

--- a/src/kubeseal_auto/secrets/creation.py
+++ b/src/kubeseal_auto/secrets/creation.py
@@ -180,10 +180,10 @@ def create_regcred_secret(secret_params: SecretParams, output_path: Path) -> Non
         secret_params.namespace,
         f"--docker-server={docker_server}",
         f"--docker-username={docker_username}",
-        f"--docker-password={docker_password}",
+        "--docker-password=-",  # read from stdin — keeps password out of /proc/*/cmdline
         _DRY_RUN_CLIENT,
         "-o",
         "yaml",
     ]
 
-    _run_kubectl_write_output(cmd, output_path, "docker-registry")
+    _run_kubectl_write_output(cmd, output_path, "docker-registry", input_data=docker_password.encode())

--- a/src/kubeseal_auto/secrets/sealing.py
+++ b/src/kubeseal_auto/secrets/sealing.py
@@ -243,6 +243,12 @@ def backup_controller_secret(
     ]
     ic(cmd)
 
+    console.warning(
+        "Backing up the controller encryption secret. "
+        "This file contains the private key that can decrypt ALL SealedSecrets "
+        "managed by this controller. Store it securely and delete it after use."
+    )
+
     output_file = f"{context_name}-secret-backup.yaml"
     try:
         with open(output_file, "w", encoding="utf-8") as f:

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -6,8 +6,48 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kubeseal_auto.core.host import Host
+from kubeseal_auto.core.host import Host, normalize_version
 from kubeseal_auto.exceptions import BinaryNotFoundError, UnsupportedPlatformError
+
+
+class TestNormalizeVersion:
+    """Tests for normalize_version function."""
+
+    def test_strips_leading_v(self) -> None:
+        """Test that leading 'v' prefix is removed."""
+        assert normalize_version("v0.26.0") == "0.26.0"
+
+    def test_preserves_version_without_v(self) -> None:
+        """Test that version without 'v' prefix is unchanged."""
+        assert normalize_version("0.26.0") == "0.26.0"
+
+    def test_semver_pre_release(self) -> None:
+        """Test semantic version with pre-release suffix."""
+        assert normalize_version("v0.26.0-beta.1") == "0.26.0-beta.1"
+
+    def test_semver_build_metadata(self) -> None:
+        """Test semantic version with build metadata."""
+        assert normalize_version("0.26.0+build.42") == "0.26.0+build.42"
+
+    def test_empty_string_raises(self) -> None:
+        """Test that empty string raises ValueError."""
+        with pytest.raises(ValueError, match="Version string cannot be None or empty"):
+            normalize_version("")
+
+    def test_bare_v_raises(self) -> None:
+        """Test that bare 'v' raises ValueError (empty after strip)."""
+        with pytest.raises(ValueError, match="Invalid version string"):
+            normalize_version("v")
+
+    def test_non_semver_raises(self) -> None:
+        """Test that non-semver string raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid version format"):
+            normalize_version("not-a-version")
+
+    def test_partial_version_raises(self) -> None:
+        """Test that partial version string raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid version format"):
+            normalize_version("0.26")
 
 
 class TestHostPlatformDetection:

--- a/tests/test_kubeseal.py
+++ b/tests/test_kubeseal.py
@@ -1,5 +1,6 @@
 """Tests for kubeseal.py module."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 import click
@@ -184,6 +185,26 @@ class TestKubesealSecretCreation:
             assert "--dry-run=client" in cmd
             assert "-o" in cmd
             assert "yaml" in cmd
+
+    def test_create_tls_secret_custom_paths(
+        self, kubeseal_mocks: dict[str, MagicMock], mock_subprocess: MagicMock  # noqa: ARG002
+    ) -> None:
+        """Test creating a TLS secret with custom key/cert paths."""
+        kubeseal = Kubeseal(select_context=False)
+        secret_params = SecretParams(name="test-tls-secret", namespace="default", secret_type=SecretType.TLS)
+
+        with (
+            patch("builtins.open", mock_open()),
+            patch("kubeseal_auto.secrets.creation.Path.exists", return_value=True),
+        ):
+            kubeseal.create_tls_secret(secret_params, key_path=Path("custom.key"), cert_path=Path("custom.crt"))
+
+            mock_subprocess.assert_called_once()
+            cmd = mock_subprocess.call_args[0][0]
+            assert "--key" in cmd
+            assert "custom.key" in cmd
+            assert "--cert" in cmd
+            assert "custom.crt" in cmd
 
     def test_create_regcred_secret(self, kubeseal_mocks: dict[str, MagicMock], mock_subprocess: MagicMock) -> None:  # noqa: ARG002
         """Test creating a docker-registry secret."""

--- a/tests/test_kubeseal.py
+++ b/tests/test_kubeseal.py
@@ -222,8 +222,10 @@ class TestKubesealSecretCreation:
             assert "default" in cmd
             assert f"--docker-server={docker_server}" in cmd
             assert f"--docker-username={docker_username}" in cmd
-            assert f"--docker-password={docker_password}" in cmd
+            assert "--docker-password=-" in cmd
             assert "--dry-run=client" in cmd
+            # Password passed via stdin, not the command line
+            assert mock_subprocess.call_args[1]["input"] == docker_password.encode()
 
     def test_create_tls_secret_missing_files(self, kubeseal_mocks: dict[str, MagicMock]) -> None:  # noqa: ARG002
         """Test creating a TLS secret with missing files raises ClickException."""

--- a/tests/test_sealing.py
+++ b/tests/test_sealing.py
@@ -226,6 +226,7 @@ class TestBackupControllerSecret:
         with (
             patch("subprocess.run") as mock_run,
             patch("builtins.open", mock_open()),
+            patch("kubeseal_auto.secrets.sealing.console.warning") as mock_warning,
         ):
             mock_run.return_value = MagicMock(returncode=0)
 
@@ -236,6 +237,8 @@ class TestBackupControllerSecret:
             )
 
             mock_run.assert_called_once()
+            mock_warning.assert_called_once()
+            assert "private key" in mock_warning.call_args[0][0]
 
     def test_backup_failure(self) -> None:
         """Test error handling when backup fails."""


### PR DESCRIPTION
  ### Changes

  - Docker registry passwords are now passed to `kubectl` via stdin
    (`--docker-password=-`) instead of as a CLI argument, keeping the
    credential out of `/proc/*/cmdline`.

  - Controller encryption key backup now shows a prominent warning
    about the file containing the private key that can decrypt all
    SealedSecrets managed by that controller. The backup output
    pattern is added to `.gitignore`.

  - `create_tls_secret` accepts optional `key_path`/`cert_path`
    keyword arguments so the TLS key and certificate files don't have
    to live in CWD. Defaults preserve existing behavior.

  - Added comprehensive unit tests for `normalize_version` covering
    valid semver, pre-release/build metadata, and edge-case errors.

  - `atexit.unregister` in the temp file cleanup path is wrapped in
    `contextlib.suppress` for defensive correctness.

  - Coverage artifacts (`*.py,cover`, `coverage.xml`) added to
    `.gitignore`.