### PR TITLE
ci: fix sealed-secrets helm repo URL and clear SonarCloud uv-flag findings

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install sealed-secrets controller
         run: |
-          helm repo add sealed-secrets https://bitnami-labs.github.io/sealed-secrets
+          helm repo add sealed-secrets https://bitnami.github.io/sealed-secrets
           helm install sealed-secrets-controller sealed-secrets/sealed-secrets \
             --namespace kube-system \
             --wait \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --group dev --locked
 
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
@@ -47,4 +47,4 @@ jobs:
         run: kubectl rollout status deployment/sealed-secrets-controller -n kube-system --timeout=120s
 
       - name: Run e2e tests
-        run: uv run pytest tests/e2e -m e2e -v
+        run: uv run --locked pytest tests/e2e -m e2e -v

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --group dev --locked
 
       - name: Run Pytest
-        run: uv run pytest -q
+        run: uv run --locked pytest -q
 
   build:
     needs: test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,10 +26,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --group dev --locked
 
       - name: Run Pytest
-        run: uv run pytest --cov=src --cov-report=xml
+        run: uv run --locked pytest --cov=src --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,10 +26,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --group dev --locked --no-build --no-install-project
 
       - name: Run bandit
-        run: uv run bandit -r src/
+        run: uv run --locked --no-build --no-sync bandit -r src/
 
   trivy:
     name: Trivy (dependency vulnerabilities)


### PR DESCRIPTION
  ## Summary

  Two CI fixes:

  1. **Helm 404 in e2e** — the `sealed-secrets` chart repo moved from
     `bitnami-labs.github.io` to `bitnami.github.io`; the old index now
     returns 404, breaking `helm repo add` in the e2e job.
  2. **SonarCloud VULNERABILITY findings** on the `uv` invocations in all
     four workflows (rules `githubactions:S8544` and `githubactions:S8541`).

  ## Changes

  - **`--locked` on every `uv sync`/`uv run`** (S8544) — CI now installs
    strictly from the committed `uv.lock` (pinned versions + hashes) instead
    of re-resolving.
  - **`security.yml` builds nothing from source** (S8541) — the bandit job
    never imports the first-party package, so it installs with
    `--no-build --no-install-project` and runs via `--no-sync`.
  - **Helm chart repo URL** corrected in `e2e.yml`.